### PR TITLE
make it easier to compile on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,22 @@
 CXXFLAGS = -std=gnu++0x -g -O0 -I$(LIBUV_PATH)/include -I$(HTTP_PARSER_PATH) -I. -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 
+OS=`uname`
+ifneq ($(NULL),$(filter Darwin,$(OS)))
+RTLIB=-lrt
+else
+RTLIB=
+endif
+
 all: webclient webserver file_test
 
 webclient: webclient.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o $(wildcard native/*.h)
-	$(CXX) $(CXXFLAGS) -o webclient webclient.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o -lrt -lm -lpthread
+	$(CXX) $(CXXFLAGS) -o webclient webclient.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o $(RTLIB) -lm -lpthread
 	
 webserver: webserver.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o $(wildcard native/*.h)
-	$(CXX) $(CXXFLAGS) -o webserver webserver.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o -lrt -lm -lpthread
+	$(CXX) $(CXXFLAGS) -o webserver webserver.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o $(RTLIB) -lm -lpthread
 	
 file_test: file_test.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o $(wildcard native/*.h)
-	$(CXX) $(CXXFLAGS) -o file_test file_test.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o -lrt -lm -lpthread
+	$(CXX) $(CXXFLAGS) -o file_test file_test.cpp $(LIBUV_PATH)/uv.a $(HTTP_PARSER_PATH)/http_parser.o $(RTLIB) -lm -lpthread
 
 $(LIBUV_PATH)/uv.a:
 	$(MAKE) -C $(LIBUV_PATH)

--- a/native/fs.h
+++ b/native/fs.h
@@ -23,8 +23,12 @@ namespace native
         static const int truncate = O_TRUNC;
         static const int no_follow = O_NOFOLLOW;
         static const int directory = O_DIRECTORY;
+#ifdef O_NOATIME
         static const int no_access_time = O_NOATIME;
+#endif
+#ifdef O_LARGEFILE
         static const int large_large = O_LARGEFILE;
+#endif
 
         namespace internal
         {


### PR DESCRIPTION
Added a few compile checks to make it a bit easier to compile for OSX.  After getting gcc 4.6 compiled this was all that was needed to compile and run the sample webserver.   May help address https://github.com/d5/node.native/issues/1
