### PR TITLE
restrict SEGV

### DIFF
--- a/native/http.h
+++ b/native/http.h
@@ -417,7 +417,11 @@ namespace native
 				};
 
 				socket_->read_start([=](const char* buf, int len){
-					http_parser_execute(&parser_, &parser_settings_, buf, len);
+					if (buf == 0x00 && len == -1) {
+						response_->set_status(500);
+					} else {
+						http_parser_execute(&parser_, &parser_settings_, buf, len);
+					}
 				});
 
 				return true;


### PR DESCRIPTION
i use webserver and stress to it by apache bench.

give -n 10000 and -c 1000 options to ab and then webserver was crashed with SEGV.

i was tracking with gdb and recognizing http.h doesnt care socket read error.

so, i fix http.h to care socket read error and set http response code as 500 when this error occured.
and webserver doesnt down now.

thank you.
